### PR TITLE
increase font size to 16px

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1,6 +1,6 @@
 html {
   height: 100%;
-  font-size: 12px;
+  font-size: 16px;
 }
 
 body {
@@ -9,7 +9,7 @@ body {
   height: 100%;
   color: rgb(74, 74, 79);
   /* #if process.env.TARGET === 'firefox'
-  font-size: 11px;
+  font-size: 15px;
   /* #endif */
   font-family: monospace;
 }


### PR DESCRIPTION
12 pixels is extremely small.

It's painful to read, and bumping it up with the DevTools open also increases the size of the font in other tabs.

This PR updates it to 16px, making it easier to read.

- is 16px _too_ big now? Maybe 14px is better, but 12px definitely feels too small.

I've attached screenshots at different font sizes, to help answer that it:

**12px**
![Screenshot 2023-03-01 at 16 01 23](https://user-images.githubusercontent.com/449004/222194864-838691c4-6e04-446b-ba03-3319e074406c.png)
**14px**
![Screenshot 2023-03-01 at 16 02 17](https://user-images.githubusercontent.com/449004/222194867-ed4c6e15-5e7f-4646-bebe-07e07d5a8fe7.png)
**16px**
![Screenshot 2023-03-01 at 16 01 31](https://user-images.githubusercontent.com/449004/222194964-805fa6b6-445a-4d2d-bc10-2c036dcc80fd.png)
