### PR TITLE
chore: remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10


### PR DESCRIPTION
We'll probably want something like renovate in kit repo for the future, but right now this is just noise.

Closes #93 
Closes #110 
Closes #113 
Closes #123 
Closes #129 
Closes #130 
Closes #131 