### PR TITLE
feat: migrate to manifest v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
-<h1 align="center">Svelte DevTools</h1>
+# Svelte DevTools
 
-<div align="center">
-  <a href="https://chrome.google.com/webstore/detail/svelte-devtools/ckolcbmkjpjmangdbmnkpjigpkddpogn">
-    <img src="https://img.shields.io/chrome-web-store/users/ckolcbmkjpjmangdbmnkpjigpkddpogn?color=blue&label=Chrome" alt="Chrome Web Store" />
-  </a>
-  <a href="https://addons.mozilla.org/en-US/firefox/addon/svelte-devtools">
-    <img src="https://img.shields.io/amo/users/svelte-devtools?color=orange&label=Firefox" alt="Mozilla Add-on" />
-  </a>
-</div>
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/users/ckolcbmkjpjmangdbmnkpjigpkddpogn?color=blue&label=Chrome)](https://chrome.google.com/webstore/detail/svelte-devtools/ckolcbmkjpjmangdbmnkpjigpkddpogn) [![Mozilla Add-on](https://img.shields.io/amo/users/svelte-devtools?color=orange&label=Firefox)](https://addons.mozilla.org/en-US/firefox/addon/svelte-devtools)
 
 Svelte DevTools is a Chrome extension for the [Svelte](https://svelte.dev/) framework. It allows you to inspect the Svelte state and component hierarchies in the Developer Tools.
 
@@ -23,7 +16,7 @@ This extensions officially supports Svelte 4.0 and above.
 
 ## Development
 
-Clone this repository and run the package script.
+Clone this repository, setup and run the build script
 
 ```sh
 git clone https://github.com/sveltejs/svelte-devtools.git

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,42 +9,9 @@ export default defineConfig([
 	},
 	{
 		input: 'src/client/index.js',
-		output: {
-			file: 'build/courier.js',
-			format: 'iife',
-			banner: `if (!window.tag) {
-  window.tag = document.createElement('script')
-  window.tag.text = \``,
-			footer: `\`
-  if (window.sessionStorage.SvelteDevToolsProfilerEnabled === "true") window.tag.text = window.tag.text.replace('let profilerEnabled = false;', '\$&\\nstartProfiler();')
-  document.children[0].append(window.tag)
-  const sendMessage = chrome.runtime.sendMessage
-  const postMessage = window.postMessage.bind(window)
-  chrome.runtime.onMessage.addListener((message, sender) => {
-    const fromBackground = sender && sender.id === chrome.runtime.id
-    if (!fromBackground) {
-      console.error('Message from unexpected sender', sender, message)
-      return
-    }
-    switch (message.type) {
-      case 'startProfiler':
-        window.sessionStorage.SvelteDevToolsProfilerEnabled = "true"
-        break
-      case 'stopProfiler':
-        // fallthrough
-      case 'clear':
-        delete window.sessionStorage.SvelteDevToolsProfilerEnabled
-        break
-    }
-    postMessage(message)
-  })
-  window.addEventListener(
-    'message',
-    e => e.source == window && sendMessage(e.data),
-    false
-  )
-  window.addEventListener('unload', () => sendMessage({ type: 'clear' }))
-}`,
-		},
+		output: [
+			{ file: 'static/courier.js', format: 'iife' },
+			{ file: 'build/courier.js', format: 'iife' },
+		],
 	},
 ]);

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -108,7 +108,7 @@ function serializeNode(node) {
 			const attributes = Array.from(node.detail.attributes || []);
 
 			/** @type {NonNullable<SvelteListenerDetail['node']['__listeners']>} */
-			const listeners = res.detail.__listeners || [];
+			const listeners = node.detail.__listeners || [];
 
 			res.detail = {
 				attributes: attributes.map(({ name: key, value }) => ({ key, value })),

--- a/src/client/svelte.js
+++ b/src/client/svelte.js
@@ -123,8 +123,8 @@ document.addEventListener('SvelteRegisterBlock', ({ detail }) => {
 					}
 
 					Promise.resolve().then(() => {
-						const invalidate = node.detail.$$?.invalidate || {};
-						Object.keys(invalidate.length).length && listeners.update(node);
+						const invalidate = node.detail.$$?.bound || {};
+						Object.keys(invalidate).length && listeners.update(node);
 					});
 					break;
 				}

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
-	"manifest_version": 2,
-	"name": "Svelte Devtools",
-	"version": "1.3.0",
+	"manifest_version": 3,
+	"name": "Svelte DevTools",
+	"version": "2.0.0",
 	"description": "Browser devtools extension for debugging Svelte applications.",
 	"icons": {
 		"16": "icons/16.png",
@@ -12,9 +12,15 @@
 	},
 
 	"background": {
-		"scripts": ["background.js"]
+		"service_worker": "background.js"
 	},
-	"devtools_page": "devtools/index.html",
-	"permissions": ["tabs", "<all_urls>"],
-	"web_accessible_resources": ["courier.js"]
+	"devtools_page": "register.html",
+	"host_permissions": ["*://*/*"],
+	"permissions": ["activeTab", "scripting"],
+	"web_accessible_resources": [
+		{
+			"resources": ["courier.js"],
+			"matches": ["*://*/*"]
+		}
+	]
 }

--- a/static/register.html
+++ b/static/register.html
@@ -1,8 +1,4 @@
-<!doctype html>
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-	</head>
+<html>
 	<body>
 		<script src="register.js"></script>
 	</body>

--- a/static/register.js
+++ b/static/register.js
@@ -1,6 +1,6 @@
 chrome.devtools.panels.create(
 	'Svelte',
-	chrome.devtools.panels.themeName == 'dark'
+	chrome.devtools.panels.themeName === 'dark'
 		? '/icons/svelte-logo-dark.svg'
 		: '/icons/svelte-logo-light.svg',
 	'/index.html',


### PR DESCRIPTION
Extracted from #133 

The Chrome Web Store no longer accepts Manifest V2 as stated from https://developer.chrome.com/docs/extensions/mv2/, this PR goes through the [migration checklist](https://developer.chrome.com/docs/extensions/migrating/) and converts the extension to use V3 APIs.

Compatibility with Firefox is a bit tricky but doable, according to https://stackoverflow.com/a/75203925

> - Chrome is not happy with `background.scripts` and insists on using `background.service_worker`
> - Firefox doesn't support `background.service_worker` and wants `background.scripts`

Before publishing to Firefox, we'll just need to replace `"service_worker": "background.js"` with `"scripts": ["background.js"]`. I've tested the extension locally on Firefox by loading it as a temporary extension and it happily accepts the `.zip` file.

However, I'm getting "Missing host permission for the tab" error on Firefox, which doesn't seem to happen with Chromium based browsers. This will need to be investigated further later on, we may need to change or add upon the `"activeTab"` permissions with `"tabs"`, but that would [trigger a warning message during installation](https://developer.chrome.com/docs/extensions/mv3/manifest/activeTab/).

---

Closes #68 - kit works out of the box
Closes #69 - should work but upgrade to svelte 4
Closes #72 - kit works without additional configuration
Closes #73 - should work with all chromium browsers
Closes #76 - should not be a problem now

Also,
Closes #70 