### PR TITLE
chore: standardize details

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
-	"name": "svelte-devtools",
-	"version": "1.3.0",
-	"description": "Browser devtools extension for debugging Svelte applications.",
-	"repository": "github:sveltejs/svelte-devtools",
-	"license": "MIT",
+	"private": true,
 	"type": "module",
 	"scripts": {
 		"dev:app": "vite build --watch",

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Svelte DevTools",
 	"version": "2.0.0",
-	"description": "Browser devtools extension for debugging Svelte applications.",
+	"description": "Browser DevTools extension for debugging Svelte applications.",
 	"icons": {
 		"16": "icons/16.png",
 		"24": "icons/24.png",


### PR DESCRIPTION
Makes `manifest.json` the source of truth.