### PR TITLE
fix: ignore inspect toggle events

### DIFF
--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -46,6 +46,7 @@ port.onMessage.addListener(({ type, payload }) => {
 		}
 
 		case 'bridge::ext/inspect': {
+			if (typeof payload === 'string') return;
 			const current = nodes.get(payload.node.id);
 			return selected.set(current);
 		}


### PR DESCRIPTION
Messages from `.postMessage` inside of the app runtime are also captured by its own `onMessage` listeners, so we need to handle those accordingly. 