### PR TITLE
chore: update upload action to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - run: pnpm build
       - run: cd build && zip -r svelte-devtools *
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: extension-${{ github.sha }}
           path: build/svelte-devtools.zip


### PR DESCRIPTION
Fixes deprecation warning, https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/