### PR TITLE
chore: add downloadable bot comment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,12 +41,18 @@ jobs:
       - if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          WORKFLOW: ${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts
         run: |
-          id=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[0].id')
-          url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/$id
-          comment="Try the changes in this PR by [side-loading the built extension]($url). :rocket:"
+          url=https://github.com/$WORKFLOW/$(gh api repos/$WORKFLOW --jq '.artifacts[0].id')
+          commented=$(gh pr view $PR_NUMBER --json comments --jq '.comments[].author.login | select(. | contains("github-actions"))')
+          body="Try the changes in this PR by [side-loading the built extension]($url). :rocket:"
 
-          gh pr comment ${{ github.event.pull_request.number }} --body "$comment"
+          if [ -z "$commented" ]; then
+            gh pr comment $PR_NUMBER --body "$body"
+          else
+            gh pr comment $PR_NUMBER --edit-last --body "$body"
+          fi
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/$id
           comment="Try the changes in this PR by [side-loading the built extension]($url). :rocket:"
 
-          gh pr comment ${{ github.event.pull_request.number }} --edit-last --body "$comment"
+          gh pr comment ${{ github.event.pull_request.number }} --body "$comment"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,16 @@ jobs:
           name: extension-${{ github.sha }}
           path: workspace/extension/build/svelte-devtools.zip
 
+      - if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          id=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[0].id')
+          url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/$id
+          comment="Try the changes in this PR by [side-loading the built extension]($url). :rocket:"
+
+          gh pr comment ${{ github.event.pull_request.number }} --edit-last --body "$comment"
+
   publish:
     runs-on: ubuntu-latest
     needs: [manifest, bundle]


### PR DESCRIPTION
Trying out changes in a PR requires many clicks to go to the actions tab and find the artifact generated from the action to download it, this change will add a bot comment that gives us the direct link to download the artifact.

One downside from using artifacts is that the user needs to be logged in to download them, an alternative we could use is to rely on a third-party service like https://nightly.link/ to generate a public link for everyone to download.