### PR TITLE
fix: document head null error

### DIFF
--- a/workspace/extension/static/background.js
+++ b/workspace/extension/static/background.js
@@ -76,7 +76,13 @@ function courier(tabId, changed) {
 			// because `detail` in the dispatched custom events is `null`
 			const script = document.createElement('script');
 			script.setAttribute('src', source);
-			document.head.appendChild(script);
+			if (document.head) {
+				document.head.appendChild(script);
+			} else {
+				document.addEventListener('DOMContentLoaded', function () {
+					document.head.appendChild(script);
+				});
+			}
 
 			chrome.runtime.onMessage.addListener((message, sender) => {
 				if (sender.id !== chrome.runtime.id) return; // unexpected sender


### PR DESCRIPTION
This is to fix https://github.com/sveltejs/svelte-devtools/issues/232

Add check for document.head. If it's null, call appendChild on the event DOMContentLoaded 