### PR TITLE
feat: add `gecko.update_url` to manifest

### DIFF
--- a/workspace/extension/static/manifest.json
+++ b/workspace/extension/static/manifest.json
@@ -33,7 +33,8 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "firefox-devtools@svelte.dev",
-			"strict_min_version": "121.0"
+			"strict_min_version": "121.0",
+			"update_url": "https://svelte.dev/devtools/updates.json"
 		}
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/sveltejs/svelte.dev/pull/673

This enables automatic updates for Firefox users that installs the extension from the `.xpi` file

Closes #207 