### PR TITLE
manifest version error when loading extension

### DIFF
--- a/workspace/extension/static/manifest.json
+++ b/workspace/extension/static/manifest.json
@@ -21,7 +21,6 @@
 		}
 	},
 	"background": {
-		"scripts": ["background.js"],
 		"service_worker": "background.js"
 	},
 	"content_scripts": [


### PR DESCRIPTION
background.scripts is deprecated in manifest v3 replaced by service_worker. when we build by using scripts then the extension loads with error but when removed , it loads fine 
more explanation is done in https://stackoverflow.com/a/65451580