### PR TITLE
feat: show error in dev tools when using unsupported Svelte version

### DIFF
--- a/workspace/extension/src/constants/version.ts
+++ b/workspace/extension/src/constants/version.ts
@@ -1,0 +1,1 @@
+export const SVELTE_SUPPORTED_MAJOR_VERSIONS: number[] = [4];

--- a/workspace/extension/src/lib/runtime.svelte.ts
+++ b/workspace/extension/src/lib/runtime.svelte.ts
@@ -44,6 +44,11 @@ function resolveEventBubble(node: any) {
 
 port.onMessage.addListener(({ type, payload }) => {
 	switch (type) {
+		case 'bridge::ext/svelte_version:set': {
+			app.svelteVersion = payload;
+			break;
+		}
+		
 		case 'bridge::ext/clear': {
 			app.nodes = {};
 			app.selected = undefined;

--- a/workspace/extension/src/lib/state.svelte.ts
+++ b/workspace/extension/src/lib/state.svelte.ts
@@ -1,5 +1,19 @@
 type Overwrite<A, B> = Omit<A, keyof B> & B;
 
+type AppState = {
+	svelteVersion?: number;
+
+	nodes: Record<string, DebugNode>;
+	root: Readonly<DebugNode[]>;
+
+	selected?: DebugNode;
+	hovered?: DebugNode;
+
+	inspecting: boolean;
+	query: string;
+}
+
+
 export type DebugNode = Overwrite<
 	SvelteBlockDetail,
 	{
@@ -28,15 +42,17 @@ export type DebugNode = Overwrite<
 	}
 >;
 
-export const app = $state({
-	nodes: {} as { [key: string]: DebugNode },
+export const app: AppState = $state({
+	svelteVersion: undefined,
+
+	nodes: {} as Record<string, DebugNode>,
 	get root() {
 		const nodes = Object.values(this.nodes);
 		return nodes.filter((node) => !node.parent);
 	},
 
-	selected: undefined as undefined | DebugNode,
-	hovered: undefined as undefined | DebugNode,
+	selected: undefined,
+	hovered: undefined,
 
 	inspecting: false,
 	query: '',

--- a/workspace/extension/src/routes/ConnectMessage.svelte
+++ b/workspace/extension/src/routes/ConnectMessage.svelte
@@ -1,9 +1,27 @@
 <script>
 	import { background } from '$lib/runtime.svelte';
+	import { app } from '$lib/state.svelte';
+	import { SVELTE_SUPPORTED_MAJOR_VERSIONS } from '../constants/version';
 </script>
 
 <main>
-	<h1 style:font-size="3rem">Svelte DevTools</h1>
+	{#if app.svelteVersion && !SVELTE_SUPPORTED_MAJOR_VERSIONS.includes(app.svelteVersion)}
+		<h1 style:font-size="3rem">Svelte DevTools</h1>
+		<p style:display="inline-flex" style:font-size="1.25rem">
+			<span>Unsupported Svelte version detected</span>
+
+			<button onclick={() => background.send('bypass::ext/page->refresh')}>reload</button>
+		</p>
+
+		<footer>
+			<p style:font-size="1rem">Svelte app is using an unsupported major version.</p>
+			<ul>
+				<li>Currently using Svelte version ^{app.svelteVersion}.0.0</li>
+				<li>Supported major versions: {SVELTE_SUPPORTED_MAJOR_VERSIONS.join(', ')}</li>
+			</ul>
+		</footer>
+	{:else}
+		<h1 style:font-size="3rem">Svelte DevTools</h1>
 	<p style:display="inline-flex" style:font-size="1.25rem">
 		<span>No Svelte app detected</span>
 
@@ -17,6 +35,7 @@
 			<li>Use Svelte version ^4.0.0?</li>
 		</ul>
 	</footer>
+	{/if}
 </main>
 
 <style>


### PR DESCRIPTION
Added display of unsupported Svelte version message in dev tools.
Also implemented Svelte version detection per browser tab, fixing an unrelated bug where the Svelte logo style would change across different browser windows based on the active tab.

Closes https://github.com/sveltejs/svelte-devtools/issues/242